### PR TITLE
feat: add `bold-is-bright` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,20 @@ contribution is welcomed!
 
 #ansi-render(
   string,
-  font:       string,
-  size:       length,
-  width:      auto or relative length,
-  height:     auto or relative length,
-  breakable:  boolean,
-  radius:     relative length or dictionary,
-  inset:      relative length or dictionary,
-  outset:     relative length or dictionary,
-  spacing:    relative length or fraction,
-  above:      relative length or fraction,
-  below:      relative length or fraction,
-  clip:       boolean,
-  theme:      terminal-themes.theme,
+  font:           string,
+  size:           length,
+  width:          auto or relative length,
+  height:         auto or relative length,
+  breakable:      boolean,
+  radius:         relative length or dictionary,
+  inset:          relative length or dictionary,
+  outset:         relative length or dictionary,
+  spacing:        relative length or fraction,
+  above:          relative length or fraction,
+  below:          relative length or fraction,
+  clip:           boolean,
+  theme:          terminal-themes.theme,
+  bold-is-bright: boolean,
 )
 ```
 
@@ -45,6 +46,7 @@ most parameters comes from [`block`]([https://](https://typst.app/docs/reference
 - `font` - font name, default is `Cascadia Code`
 - `size` - font size, default is `9pt`
 - `theme` - theme, default is `vscode-light`
+- `bold-is-bright` - boolean whether bold text should always be rendered with bright colors, default is `false`
 - parameters from [`block`]([https://](https://typst.app/docs/reference/layout/block/)) function with the same default value, change to adjust the outmost layout:
   - `width`
   - `height`

--- a/ansi-render.typ
+++ b/ansi-render.typ
@@ -314,7 +314,9 @@
   above: 1.2em,
   below: 1.2em,
   clip: false,
-  theme: terminal-themes.vscode-light) = {
+  theme: terminal-themes.vscode-light,
+  bold-is-bright: false,
+) = {
   // dict with text style
   let match-text = (
     "1": (weight: "bold"),
@@ -504,6 +506,16 @@
     option.bg += m.bg
     if m.reverse != none { option.reverse = m.reverse }
     if option.reverse { (option.text.fill, option.bg.fill) = (option.bg.fill, option.text.fill) }
+    if option.text.weight == "bold" and bold-is-bright {
+      if option.text.fill == theme.black { option.text.fill = theme.gray }
+      if option.text.fill == theme.red { option.text.fill = theme.bright-red }
+      if option.text.fill == theme.green { option.text.fill = theme.bright-green }
+      if option.text.fill == theme.yellow { option.text.fill = theme.bright-yellow }
+      if option.text.fill == theme.blue { option.text.fill = theme.bright-blue }
+      if option.text.fill == theme.magenta { option.text.fill = theme.bright-magenta }
+      if option.text.fill == theme.cyan { option.text.fill = theme.bright-cyan }
+      if option.text.fill == theme.white { option.text.fill = theme.bright-white }
+    }
     if m.ul != none { option.ul = m.ul }
     if m.ol != none { option.ol = m.ol }
 

--- a/test/demo.typ
+++ b/test/demo.typ
@@ -42,3 +42,22 @@ theme: terminal-themes.vscode
 
 = Uses the font supports ligatures
 #ansi-render(read("test.txt"), font: "CaskaydiaCove Nerd Font Mono", inset: 5pt, radius: 3pt, theme: terminal-themes.putty)
+
+= Render bold text with bright colors
+#let bold-bright-test = "
+\u{1b}[30mTest \u{1b}[90mTest \u{1b}[1;30mTest \u{1b}[90mTest\u{1b}[0m
+\u{1b}[31mTest \u{1b}[91mTest \u{1b}[1;31mTest \u{1b}[91mTest\u{1b}[0m
+\u{1b}[32mTest \u{1b}[92mTest \u{1b}[1;32mTest \u{1b}[92mTest\u{1b}[0m
+\u{1b}[33mTest \u{1b}[93mTest \u{1b}[1;33mTest \u{1b}[93mTest\u{1b}[0m
+\u{1b}[34mTest \u{1b}[94mTest \u{1b}[1;34mTest \u{1b}[94mTest\u{1b}[0m
+\u{1b}[35mTest \u{1b}[95mTest \u{1b}[1;35mTest \u{1b}[95mTest\u{1b}[0m
+\u{1b}[36mTest \u{1b}[96mTest \u{1b}[1;36mTest \u{1b}[96mTest\u{1b}[0m
+\u{1b}[37mTest \u{1b}[97mTest \u{1b}[1;37mTest \u{1b}[97mTest\u{1b}[0m
+".trim()
+
+#grid(
+  columns: 2,
+  gutter: 10pt,
+  ansi-render(bold-bright-test, inset: 5pt, radius: 3pt, theme: terminal-themes.vintage),
+  ansi-render(bold-bright-test, inset: 5pt, radius: 3pt, theme: terminal-themes.vintage, bold-is-bright: true),
+)


### PR DESCRIPTION
Many terminal emulators provide an option to always render bold text using the bright colors. This PR adds the `bold-is-bright` option for exactly that. It defaults to `false` to mirror the previous behavior.

<img alt="demo" width="500" src="https://github.com/8LWXpg/typst-ansi-render/assets/35602040/1eefb662-8f1c-4a0a-ab14-92d128e3b21e"></img>

On the left is the current behavior, on the right is with the setting enabled. Only the third column is different.

> [!NOTE]
> I added this example to the `demo.typ` file, but you may want to recompile the `demo.pdf` yourself as I did not have the required fonts installed.
