### PR TITLE
feat: allow setting `font` to `none`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ contribution is welcomed!
 
 #ansi-render(
   string,
-  font:       string,
+  font:       string or none,
   size:       length,
   width:      auto or relative length,
   height:     auto or relative length,
@@ -42,7 +42,7 @@ contribution is welcomed!
 most parameters comes from [`block`]([https://](https://typst.app/docs/reference/layout/block/)) function, adjust the layout outmost block.
 
 - `string` - string with ANSI escape sequences
-- `font` - font name, default is `Cascadia Code`
+- `font` - font name or none, default is `Cascadia Code`
 - `size` - font size, default is `9pt`
 - `theme` - theme, default is `vscode-light`
 - parameters from [`block`]([https://](https://typst.app/docs/reference/layout/block/)) function with the same default value, change to adjust the outmost layout:

--- a/ansi-render.typ
+++ b/ansi-render.typ
@@ -461,7 +461,8 @@
     arr
   }
 
-  set text(..(match-text.default), font: font, size: size, top-edge: "ascender", bottom-edge: "descender")
+  if font != none { match-text.default += (font: font) }
+  set text(..(match-text.default), size: size, top-edge: "ascender", bottom-edge: "descender")
   set par(leading: 0em)
 
   let option = (
@@ -522,7 +523,11 @@
       } else {
         c
       }
-      [#str]
+      if font == none {
+        [#raw(str)]
+      } else {
+        [#str]
+      }
     }
     // fill trailing newlines
     let s = str.find(regex("\n+$"))


### PR DESCRIPTION
When set to `none`, the default monospace font which is used for `raw` code blocks will be used. The default is left as `Cascadia Code` so that this is not a breaking change.

<img alt="demo" width="500" src="https://github.com/8LWXpg/typst-ansi-render/assets/35602040/331b3e5c-ae52-41c4-9ef0-66118d1e33f7"></img>

```typ
#import "../ansi-render.typ": *

#set page(width: auto, height: auto, margin: 10pt)

#let demo-text = "\u{1b}[38;2;255;0;0mThis text is red.\u{1b}[0m
\u{1b}[48;2;0;255;0mThis background is green.\u{1b}[0m
\u{1b}[38;2;255;255;255m\u{1b}[48;2;0;0;255mThis text is white on a blue background.\u{1b}[0m
\u{1b}[1mThis text is bold.\u{1b}[0m
\u{1b}[4mThis text is underlined.\u{1b}[0m
\u{1b}[38;2;255;165;0m\u{1b}[48;2;255;255;0mThis text is orange on a yellow background.\u{1b}[0m
"

#ansi-render(
  demo-text,
  inset: 5pt,
  radius: 3pt,
  theme: terminal-themes.vscode,
  font: "invalid font",
)
#ansi-render(
  demo-text,
  inset: 5pt,
  radius: 3pt,
  theme: terminal-themes.vscode,
  font: none,
)
#ansi-render(
  demo-text,
  inset: 5pt,
  radius: 3pt,
  theme: terminal-themes.vscode,
  font: "JetBrains Mono",
)
```