### PR TITLE
fix: 8-bit colors 8-15 use the wrong colors

### DIFF
--- a/ansi-render.typ
+++ b/ansi-render.typ
@@ -369,7 +369,7 @@
       num = int(num)
       let colors = (0, 95, 135, 175, 215, 255)
       if num <= 7 { match-text.at(str(num+30)) }
-      else if num <= 15 { match-bg.at(str(num+32)) }
+      else if num <= 15 { match-text.at(str(num+82)) }
       else if num <= 231 {
         num -= 16
         let (r, g, b) = (colors.at(int(num/36)), colors.at(calc.rem(int(num/6),6)), colors.at(calc.rem(num,6)))


### PR DESCRIPTION
The 8-bit colors between `8` and `15` should use the bright colors, not the normal ones. An escape sequence of `\x1b[91m` should be equivalent to `\x1b[38;5;9m`.

In these images, the first and third column should look equal (normal colors) and the second and fourth column should look equal (bright colors). The first image was the behavior before this PR, the second image shows the new behavior.

<p>
<img alt="old behavior" width="300" src="https://github.com/8LWXpg/typst-ansi-render/assets/35602040/30b88dad-29ba-4ed0-94c4-1e3f3bce7560"></img>
<img alt="new behavior" width="300" src="https://github.com/8LWXpg/typst-ansi-render/assets/35602040/44e0486d-ec8c-47e6-8e1c-0b1a285ecb48"></img>
</p>

```typ
#ansi-render(
"
\u{1b}[40m \u{1b}[100m \u{1b}[48;5;0m \u{1b}[48;5;8m \u{1b}[0m\u{1b}[30mX\u{1b}[90mX\u{1b}[38;5;0mX\u{1b}[38;5;8mX\u{1b}[0m
\u{1b}[41m \u{1b}[101m \u{1b}[48;5;1m \u{1b}[48;5;9m \u{1b}[0m\u{1b}[31mX\u{1b}[91mX\u{1b}[38;5;1mX\u{1b}[38;5;9mX\u{1b}[0m
\u{1b}[42m \u{1b}[102m \u{1b}[48;5;2m \u{1b}[48;5;10m \u{1b}[0m\u{1b}[32mX\u{1b}[92mX\u{1b}[38;5;2mX\u{1b}[38;5;10mX\u{1b}[0m
\u{1b}[43m \u{1b}[103m \u{1b}[48;5;3m \u{1b}[48;5;11m \u{1b}[0m\u{1b}[33mX\u{1b}[93mX\u{1b}[38;5;3mX\u{1b}[38;5;11mX\u{1b}[0m
\u{1b}[44m \u{1b}[104m \u{1b}[48;5;4m \u{1b}[48;5;12m \u{1b}[0m\u{1b}[34mX\u{1b}[94mX\u{1b}[38;5;4mX\u{1b}[38;5;12mX\u{1b}[0m
\u{1b}[45m \u{1b}[105m \u{1b}[48;5;5m \u{1b}[48;5;13m \u{1b}[0m\u{1b}[35mX\u{1b}[95mX\u{1b}[38;5;5mX\u{1b}[38;5;13mX\u{1b}[0m
\u{1b}[46m \u{1b}[106m \u{1b}[48;5;6m \u{1b}[48;5;14m \u{1b}[0m\u{1b}[36mX\u{1b}[96mX\u{1b}[38;5;6mX\u{1b}[38;5;14mX\u{1b}[0m
\u{1b}[47m \u{1b}[107m \u{1b}[48;5;7m \u{1b}[48;5;15m \u{1b}[0m\u{1b}[37mX\u{1b}[97mX\u{1b}[38;5;7mX\u{1b}[38;5;15mX\u{1b}[0m
",
theme: terminal-themes.vintage,
)
```